### PR TITLE
updated open api to new version

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -48,6 +48,8 @@ class Configuration implements ConfigurationInterface
                     ->end()
                     ->scalarNode('pathToPhantom')
                     ->end()
+                    ->scalarNode('apiKey')
+                    ->end()
                 ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/StevListaFirmeExtension.php
+++ b/DependencyInjection/StevListaFirmeExtension.php
@@ -12,25 +12,43 @@ use Symfony\Component\DependencyInjection\Loader;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class StevListaFirmeExtension extends Extension {
+class StevListaFirmeExtension extends Extension
+{
 
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container) {
+    public function load(array $configs, ContainerBuilder $container)
+    {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
         if ($config['cifChecker'] == \Stev\ListaFirmeBundle\Lib\CIFChecker::CHECKER_LISTA_FIRME) {
-            if (!isset($config['username']) || $config['password']) {
-                throw new \RuntimeException('Username and password are mandatory for listaFirme checker');
-            }
+            
         } elseif ($config['cifChecker'] == \Stev\ListaFirmeBundle\Lib\CIFChecker::CHECKER_MFIN) {
-            if (!isset($config['pathToPhantom'])) {
-                $config['pathToPhantom'] = $container->getParameter('kernel.root_dir') . '/../bin/phantomjs';
-            }
+            
+        }
+
+        switch ($config['cifChecker']) {
+            case \Stev\ListaFirmeBundle\Lib\CIFChecker::CHECKER_LISTA_FIRME:
+                if (!isset($config['username']) || $config['password']) {
+                    throw new \RuntimeException('Username and password are mandatory for listaFirme checker');
+                }
+                break;
+            case \Stev\ListaFirmeBundle\Lib\CIFChecker::CHECKER_MFIN:
+                if (!isset($config['pathToPhantom'])) {
+                    $config['pathToPhantom'] = $container->getParameter('kernel.root_dir') . '/../bin/phantomjs';
+                }
+                break;
+            case \Stev\ListaFirmeBundle\Lib\CIFChecker::CHECKER_OPEN_API:
+                if (!isset($config['apiKey'])) {
+                    throw new \RuntimeException('ApiKey is mandatory for OpenAPI checker since 15.09.2016');
+                }
+                break;
+            default:
+                break;
         }
 
         $container->setParameter('stev_lista_firme.cifChecker', $config['cifChecker']);
@@ -39,6 +57,7 @@ class StevListaFirmeExtension extends Extension {
         $container->setParameter('stev_lista_firme.offline', $config['offline']);
         $container->setParameter('stev_lista_firme.enabled', $config['enabled']);
         $container->setParameter('stev_lista_firme.pathToPhantom', isset($config['pathToPhantom']) ? $config['pathToPhantom'] : null );
+        $container->setParameter('stev_lista_firme.apiKey', $config['apiKey']);
 
         $loader->load('services.yml');
     }

--- a/Lib/CIFChecker.php
+++ b/Lib/CIFChecker.php
@@ -29,7 +29,7 @@ class CIFChecker {
      * @param bool $enabled If you set it to false it will completly disable the checker.
      * @param LoggerInterface
      */
-    public function __construct($cifChecker, $username, $password, $offline = false, $enabled = true, $pathToPhantom = null, \Psr\Log\LoggerInterface $logger) {
+    public function __construct($cifChecker, $username, $password, $offline = false, $enabled = true, $pathToPhantom = null, \Psr\Log\LoggerInterface $logger, $apiKey = null) {
         $this->logger = $logger;
         switch ($cifChecker) {
             case self::CHECKER_LISTA_FIRME:
@@ -39,7 +39,7 @@ class CIFChecker {
                 $this->checker = new MFin($offline, $enabled, $pathToPhantom);
                 break;
             case self::CHECKER_OPEN_API:
-                $this->checker = new OpenAPI($offline, $enabled);
+                $this->checker = new OpenAPI($offline, $enabled, $apiKey);
                 break;
             default:
                 throw new \InvalidArgumentException('You provided an invalid cifChecker ' . $cifChecker);
@@ -59,12 +59,15 @@ class CIFChecker {
     private function validateResponse($response, $cui) {
 
         if (!$response instanceof Response) {
+            $this->logger->critical('Unable to verify company CUI ' . $cui);
+            $this->logger->critical('The response was ' . (string) $response);
+            
             return false;
         }
 
         if (!$response->getNume() || !$response->getCui() || !$response->getNrInmatr() || !$response->getFullAddress()) {
 
-            $this->logger->critical('Unable to verify company CUI ' . $cui);
+            $this->logger->critical('Unable to find all details of company CUI ' . $cui);
             $this->logger->critical('The response was ' . (string) $response);
 
             return false;

--- a/Lib/OpenAPI.php
+++ b/Lib/OpenAPI.php
@@ -13,22 +13,34 @@ namespace Stev\ListaFirmeBundle\Lib;
  *
  * http://openapi.ro
  */
-class OpenAPI extends AbstractCIFChecker implements CIFCheckerInterface {
+class OpenAPI extends AbstractCIFChecker implements CIFCheckerInterface
+{
 
-    protected $baseUri = 'http://openapi.ro/api/companies/';
+    protected $baseUri = 'https://api.openapi.ro/api/companies/';
 
     /**
      *
      * @var \Guzzle\Http\Client
      */
     protected $client;
+    protected $apiKey;
 
     /**
      *
      * @param bool $offline Set it to true if list firme is down or if you want to disable the check. It will make the check to return a mocked(dummy) response.
      */
-    public function __construct($offline = false, $enabled = true) {
+    public function __construct($offline = false, $enabled = true, $apiKey)
+    {
         parent::__construct($offline, $enabled);
+
+        $this->apiKey = $apiKey;
+
+        $this->init();
+    }
+
+    private function init()
+    {
+        $this->client = new \GuzzleHttp\Client();
     }
 
     /**
@@ -40,29 +52,41 @@ class OpenAPI extends AbstractCIFChecker implements CIFCheckerInterface {
      *
      * 
      */
-    protected function check($cui) {
-
-        $this->client = new \GuzzleHttp\Client();
-
-        $this->baseUri .= $cui . '.json';
+    protected function check($cui)
+    {
+        $this->baseUri .= $cui;
 
         try {
-            $response = $this->client->get($this->baseUri);
+
+            $response = $this->client->get($this->baseUri, array('headers' => array('x-api-key' => $this->apiKey)));
         } catch (\GuzzleHttp\Exception\ClientException $e) {
-            return null;
+
+            return $e->getMessage();
         }
 
-        if ($response->getStatusCode() != 200) {
-            //CUI-ul nu a fost gasit in OpenAPI
-            return null;
+        switch ($response->getStatusCode()) {
+            case 200:
+                //CIF-ul a fost găsit în baza de date, se returnează datele firmei 
+                return $this->parseResponse($response);
+                break;
+            case 202:
+                //CIF-ul nu a fost găsit în baza de date și este valid
+                return 'CIF-ul nu a fost gasit in baza de date dar este valid';
+                break;
+            default:
+                //CIF-ul nu a fost găsit în baza de date și nu este valid
+                return 'Raspuns necunoscut!';
+                break;
         }
+    }
 
+    protected function parseResponse(\Psr\Http\Message\ResponseInterface $response)
+    {
         $ret = (string) $response->getBody();
 
         $data = json_decode($ret);
 
         if (false === $data || null === $data) {
-            $ret = trim(str_replace(array(' ', '-'), '_', $ret));
 
             throw new \Exception('CUI-ul nu a putut fi validat!');
         }
@@ -73,24 +97,46 @@ class OpenAPI extends AbstractCIFChecker implements CIFCheckerInterface {
     /**
      * 
      * @param array $data
-     * {"cif":"13548146","address":"B-dul Mihai Viteazu 7",
-     * "city":"Sibiu","fax":null,"name":"Cubus Arts S.R.L.",
-     * "phone":"0269232192","registration_id":"J32/508/2000",
-     * "authorization_number":null,"company_status":"Inregistrat Din Data 23 November 2000",
-     * "state":"Sibiu","vat":"1","zip":"550350",
-     * "created_at":"2012-01-20T21:48:09.000+00:00","updated_at":"2015-05-09T18:10:09.000+00:00","company_status_updated_at":"2000-11-23"}
+     * {
+      "ultima_prelucrare": "2015-06-22",
+      "ultima_declaratie": "2015-06-19",
+      "tva_la_incasare": [],
+      "tva": null,
+      "telefon": null,
+      "stare": "INREGISTRAT din data 25 Februarie 2015",
+      "radiata": false,
+      "numar_reg_com": "J22/314/2015",
+      "meta": {
+      "updated_at": "2016-09-10T00:41:59.028403",
+      "last_changed_at": null
+      },
+      "judet": "Iași",
+      "impozit_profit": null,
+      "impozit_micro": "2015-02-27",
+      "fax": null,
+      "denumire": "Nima Software S.R.L.",
+      "cod_postal": null,
+      "cif": "34150371",
+      "adresa": "Str. Ion Creangă, 52, Iași",
+      "act_autorizare": null,
+      "accize": null
+      }
      */
-    protected function buildResponse($data) {
+    protected function buildResponse($data)
+    {
         $response = new Response();
 
-        $response->setNume($data->name);
+        $response->setNume($data->denumire);
         $response->setCui($data->cif);
-        $response->setNrInmatr($data->registration_id);
-        $response->setJudet($data->state);
-        $response->setLocalitate($data->city);
-        $response->setAdresa($data->address);
-        $response->setActualizat($data->company_status);
-        $response->setTva((bool) $data->vat);
+        $response->setNrInmatr($data->numar_reg_com);
+        $response->setJudet($data->judet);
+
+        $adresaCompleta = explode(',', $data->adresa);
+
+        $response->setLocalitate($adresaCompleta[2]);
+        $response->setAdresa($adresaCompleta[0] . ', ' . $adresaCompleta[1]);
+        $response->setActualizat($data->stare);
+        $response->setTva((bool) $data->tva);
 
         return $response;
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,6 +9,7 @@ services:
             - %stev_lista_firme.enabled%
             - %stev_lista_firme.pathToPhantom%
             - @logger
+            - %stev_lista_firme.apiKey%
 
     stev.lista_firme.validator.is_valid_company:
         class: Stev\ListaFirmeBundle\Validator\Constraints\IsValidCompanyValidator


### PR DESCRIPTION
This update introduces BC to openAPI.

If you need the old API from openAPI.ro then use legacy.openapi.ro

Check http://openapi.ro/ for more details:
Below is their original message.

22 aug 2016 ANUNȚ IMPORTANT
Vă anunțăm cu plăcere că openapi a fost rescris complet, cu multe îmbunătățiri:

datele sunt actualizate mult mai repede (CIF-uri valide și neradiate vor fi actualizate aprox. odată la 3-4 zile)
sunt disponibile și alte informații, cum ar fi bilanțul (care include printre altele și codul CAEN)
openapi a fost mutat pe un server dedicat
timpul de răspuns a fost îmbunătățit
Momentan suntem într-o perioadă de beta.

Migrare
denumirea câmpurilor diferă, am decis să păstrăm denumirea română pentru a evita confuzii
câmpul city nu mai există, câmpul adresă include și localitatea
sunt disponibile câmpuri adiționale (vom pune la dispoziție o documentație mai comprehensivă în viitor)
am renunțat la formatul XML
vă rugăm trimiteți toate cererile pe HTTPS
veți avea nevoie de un cont care vă permite generarea unei chei API, care este obligatorie
